### PR TITLE
Fix BalanceCommand: prefer currency arg and avoid Mojang lookups; add…

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,9 @@ Permissions shown in parentheses are required to run the command. Commands witho
 | Command | Description | Permission |
 | --- | --- | --- |
 | `/balance` | View your balance. | — |
+| `/balance <currency>` | View your balance in the specified currency (player only). | — |
 | `/balance <player>` | View another player's balance. | `ezeconomy.balance.others` |
+| `/balance <player> <currency>` | View another player's balance in the specified currency. | `ezeconomy.balance.others` |
 | `/baltop [amount]` | View the top balances. | — |
 | `/pay <player> <amount>` | Send money to another player. | `ezeconomy.pay` |
 | `/currency [currency]` | View or set your preferred currency.  | `ezeconomy.currency` |

--- a/src/main/java/com/skyblockexp/ezeconomy/command/BalanceCommand.java
+++ b/src/main/java/com/skyblockexp/ezeconomy/command/BalanceCommand.java
@@ -41,33 +41,48 @@ public class BalanceCommand implements CommandExecutor {
             return true;
         } else if (args.length == 1) {
             // /balance <currency> OR /balance <player>
-            OfflinePlayer target = Bukkit.getOfflinePlayer(args[0]);
-            if (target.hasPlayedBefore() || target.isOnline()) {
-                // /balance <player>
-                if (!sender.hasPermission("ezeconomy.balance.others")) {
-                    MessageUtils.send(sender, plugin, "no_permission_others_balance");
-                    return true;
-                }
-                String currency = preferenceManager.getPreferredCurrency(target.getUniqueId());
-                double balance = storage != null ? storage.getBalance(target.getUniqueId(), currency) : plugin.getEconomy().getBalance(target);
-                MessageUtils.send(sender, plugin, "others_balance", java.util.Map.of("player", target.getName(), "balance", plugin.formatPriceForMessage(balance, currency), "currency", currency));
-                return true;
-            } else {
-                // /balance <currency>
+            String lower = args[0].toLowerCase();
+            // Prefer treating the argument as a currency if it matches configured currencies.
+            if (currencies.containsKey(lower) || currencies.containsKey(args[0])) {
                 if (!(sender instanceof Player)) {
                     MessageUtils.send(sender, plugin, "only_players");
                     return true;
                 }
                 Player player = (Player) sender;
-                String currency = args[0].toLowerCase();
-                if (!currencies.containsKey(currency)) {
-                    MessageUtils.send(sender, plugin, "unknown_currency", java.util.Map.of("currency", currency));
-                    return true;
-                }
+                String currency = lower;
                 double balance = storage != null ? storage.getBalance(player.getUniqueId(), currency) : plugin.getEconomy().getBalance(player);
                 MessageUtils.send(sender, plugin, "your_balance", java.util.Map.of("balance", plugin.formatPriceForMessage(balance, currency), "currency", currency));
                 return true;
             }
+
+            // Otherwise treat as a player name. Check online players first to avoid Mojang lookups.
+            Player online = Bukkit.getPlayerExact(args[0]);
+            OfflinePlayer target = null;
+            if (online != null) {
+                target = online;
+            } else {
+                try {
+                    target = Bukkit.getOfflinePlayer(args[0]);
+                } catch (Exception ex) {
+                    MessageUtils.send(sender, plugin, "player_not_found");
+                    return true;
+                }
+            }
+
+            if (target == null || (!target.hasPlayedBefore() && !target.isOnline())) {
+                MessageUtils.send(sender, plugin, "player_not_found");
+                return true;
+            }
+
+            // /balance <player>
+            if (!sender.hasPermission("ezeconomy.balance.others")) {
+                MessageUtils.send(sender, plugin, "no_permission_others_balance");
+                return true;
+            }
+            String currency = preferenceManager.getPreferredCurrency(target.getUniqueId());
+            double balance = storage != null ? storage.getBalance(target.getUniqueId(), currency) : plugin.getEconomy().getBalance(target);
+            MessageUtils.send(sender, plugin, "others_balance", java.util.Map.of("player", target.getName(), "balance", plugin.formatPriceForMessage(balance, currency), "currency", currency));
+            return true;
         } else if (args.length == 2) {
             // /balance <player> <currency>
             if (!sender.hasPermission("ezeconomy.balance.others")) {

--- a/src/test/java/com/skyblockexp/ezeconomy/feature/BalanceCommandFeatureTest.java
+++ b/src/test/java/com/skyblockexp/ezeconomy/feature/BalanceCommandFeatureTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 import com.skyblockexp.ezeconomy.core.EzEconomyPlugin;
 import com.skyblockexp.ezeconomy.feature.support.TestSupport;
@@ -140,6 +141,9 @@ public class BalanceCommandFeatureTest {
 
         boolean result = sender.performCommand("balance HeadHunterXp");
         assertTrue(result);
+        // verify the returned message contains the expected formatted amount and symbol
+        String msg = ((PlayerMock) sender).nextMessage();
+        assertTrue(msg.contains("42") && msg.toLowerCase().contains("hh"));
     }
 
     @Test
@@ -160,7 +164,11 @@ public class BalanceCommandFeatureTest {
         // set balance for the target in lower-case currency key
         storage.setBalance(target.getUniqueId(), "headhunterxp", 21.0);
 
+        // grant permission to view others' balances
+        sender.setOp(true);
         boolean result = sender.performCommand("balance Meessem HeadHunterXp");
         assertTrue(result);
+        String msg = ((PlayerMock) sender).nextMessage();
+        assertTrue(msg.contains("Meessem") && msg.contains("21") && msg.toLowerCase().contains("hh"));
     }
 }

--- a/src/test/java/com/skyblockexp/ezeconomy/feature/BalanceCommandFeatureTest.java
+++ b/src/test/java/com/skyblockexp/ezeconomy/feature/BalanceCommandFeatureTest.java
@@ -119,4 +119,48 @@ public class BalanceCommandFeatureTest {
         boolean result = sender.performCommand("balance");
         assertTrue(result);
     }
+
+    @Test
+    public void testBalanceCommand_singleArg_customCurrency_isRecognized() throws Exception {
+        Object senderObj = server.getClass().getMethod("addPlayer", String.class).invoke(server, "ccPlayer");
+        org.bukkit.entity.Player sender = (org.bukkit.entity.Player) senderObj;
+
+        TestSupport.MockStorage storage = new TestSupport.MockStorage();
+        TestSupport.injectField(plugin, "storage", storage);
+
+        // Configure a custom currency with mixed case (edge-case)
+        plugin.getConfig().set("multi-currency.enabled", true);
+        plugin.getConfig().set("multi-currency.default", "dollar");
+        plugin.getConfig().set("multi-currency.currencies.HeadHunterXp.symbol", "HH");
+        plugin.getConfig().set("multi-currency.currencies.HeadHunterXp.decimals", 2);
+
+        java.util.UUID uuid = sender.getUniqueId();
+        // storage keys are expected to be lower-case by command logic, so set both to be safe
+        storage.setBalance(uuid, "headhunterxp", 42.0);
+
+        boolean result = sender.performCommand("balance HeadHunterXp");
+        assertTrue(result);
+    }
+
+    @Test
+    public void testBalanceCommand_playerAndCustomCurrency_worksForOthers() throws Exception {
+        Object senderObj = server.getClass().getMethod("addPlayer", String.class).invoke(server, "admin");
+        org.bukkit.entity.Player sender = (org.bukkit.entity.Player) senderObj;
+
+        Object targetObj = server.getClass().getMethod("addPlayer", String.class).invoke(server, "Meessem");
+        org.bukkit.entity.Player target = (org.bukkit.entity.Player) targetObj;
+
+        TestSupport.MockStorage storage = new TestSupport.MockStorage();
+        TestSupport.injectField(plugin, "storage", storage);
+
+        // Ensure currency is configured
+        plugin.getConfig().set("multi-currency.enabled", true);
+        plugin.getConfig().set("multi-currency.currencies.HeadHunterXp.symbol", "HH");
+
+        // set balance for the target in lower-case currency key
+        storage.setBalance(target.getUniqueId(), "headhunterxp", 21.0);
+
+        boolean result = sender.performCommand("balance Meessem HeadHunterXp");
+        assertTrue(result);
+    }
 }


### PR DESCRIPTION
- Fixed `/balance <player> <currency>` when using a custom currency (outside default `dollar`, `euro`, `gems`) 
- Updated commands documentation of the `/balance` command