### PR TITLE
docs: restructure navigation and improve server-owner documentation

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,3 +1,10 @@
+---
+title: API Guide
+nav_order: 1
+parent: Developer Reference
+has_children: true
+---
+
 # Developer API (v2)
 
 > EzEconomy is a Vault-compatible, standalone economy API with multi-currency and bank support. It is designed for plugin developers who need robust, extensible economic features.

--- a/docs/api/event/BankPostTransactionEvent.md
+++ b/docs/api/event/BankPostTransactionEvent.md
@@ -1,3 +1,10 @@
+---
+title: BankPostTransactionEvent
+nav_order: 6
+parent: API Guide
+grand_parent: Developer Reference
+---
+
 # BankPostTransactionEvent
 
 Description

--- a/docs/api/event/BankPreTransactionEvent.md
+++ b/docs/api/event/BankPreTransactionEvent.md
@@ -1,3 +1,10 @@
+---
+title: BankPreTransactionEvent
+nav_order: 5
+parent: API Guide
+grand_parent: Developer Reference
+---
+
 # BankPreTransactionEvent
 
 Description

--- a/docs/api/event/PlayerPayPlayerEvent.md
+++ b/docs/api/event/PlayerPayPlayerEvent.md
@@ -1,3 +1,10 @@
+---
+title: PlayerPayPlayerEvent
+nav_order: 4
+parent: API Guide
+grand_parent: Developer Reference
+---
+
 # PlayerPayPlayerEvent
 
 Class: `com.skyblockexp.ezeconomy.api.events.PlayerPayPlayerEvent`

--- a/docs/api/event/PostTransactionEvent.md
+++ b/docs/api/event/PostTransactionEvent.md
@@ -1,3 +1,10 @@
+---
+title: PostTransactionEvent
+nav_order: 3
+parent: API Guide
+grand_parent: Developer Reference
+---
+
 # PostTransactionEvent
 
 Class: `com.skyblockexp.ezeconomy.api.events.PostTransactionEvent`

--- a/docs/api/event/PreTransactionEvent.md
+++ b/docs/api/event/PreTransactionEvent.md
@@ -1,3 +1,10 @@
+---
+title: PreTransactionEvent
+nav_order: 2
+parent: API Guide
+grand_parent: Developer Reference
+---
+
 # PreTransactionEvent
 
 Class: `com.skyblockexp.ezeconomy.api.events.PreTransactionEvent`

--- a/docs/api/event/TransactionType.md
+++ b/docs/api/event/TransactionType.md
@@ -1,3 +1,10 @@
+---
+title: TransactionType
+nav_order: 1
+parent: API Guide
+grand_parent: Developer Reference
+---
+
 # TransactionType
 
 Enum: `com.skyblockexp.ezeconomy.api.events.TransactionType`

--- a/docs/api/storage-provider.md
+++ b/docs/api/storage-provider.md
@@ -1,3 +1,9 @@
+---
+title: Storage Provider API
+nav_order: 2
+parent: Developer Reference
+---
+
 # Custom Storage Providers for EzEconomy
 
 EzEconomy supports pluggable storage backends for all economy, bank, and currency operations. You can implement your own provider to use a custom database, cloud service, or any data source.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,11 +1,11 @@
 ---
-title: Database
+title: Storage Backends
 nav_order: 6
 ---
 
-# Database Documentation
+# Storage Backends
 
-This document describes the database structures and setup procedures for the different storage providers supported by EzEconomy.
+This page covers the setup, table/collection schemas, and data-safety guidance for each storage provider supported by EzEconomy.
 
 ## Overview
 
@@ -302,3 +302,28 @@ Currently, there is no automatic migration tool. To switch providers:
 1. **Permission denied**: Ensure the plugin has write access to the data folder
 2. **Connection failed**: Check database credentials and network connectivity
 3. **Table creation failed**: Ensure the database user has CREATE privileges
+
+## Backups
+
+Economy data is critical — regular backups prevent irreversible loss.
+
+### File-based (YML / SQLite)
+
+- **YML**: Back up the entire `plugins/EzEconomy/data/` folder. Files are plain YAML, so any file-copy or rsync job works.
+- **SQLite**: Copy `plugins/EzEconomy/ezeconomy.db`. Stop the server (or flush writes) before copying to avoid a partial snapshot.
+
+Recommended schedule: daily off-peak backup retained for at least 7 days.
+
+### Database-based (MySQL / MongoDB)
+
+- **MySQL**: Use `mysqldump ezeconomy_db > backup.sql` or a managed backup from your hosting provider. Schedule via cron.
+- **MongoDB**: Use `mongodump --db ezeconomy --out /backups/$(date +%F)`. Ensure the dump path is on a separate volume.
+
+Retain enough history to undo accidental resets or corrupted data — at least 3 daily snapshots.
+
+### Restore procedure
+
+1. Stop the server.
+2. Restore the backup file(s) to the correct location.
+3. For MySQL/MongoDB, import the dump into the same database name.
+4. Start the server and verify with `/balance` and `/ezeconomy database test`.

--- a/docs/developer-api.md
+++ b/docs/developer-api.md
@@ -1,12 +1,47 @@
 ---
-title: Developer API
-nav_order: 7
+title: Developer Reference
+nav_order: 11
+has_children: true
 ---
 
-# Developer API (v2)
+# Developer Reference
 
-This file has moved to the API folder. See the full developer API documentation at:
+This section is for plugin developers integrating with or extending EzEconomy.
 
-- [docs/api/README.md](api/README.md)
+## Contents
 
-The new location contains the complete Developer API guide, examples, and links to storage and command docs.
+| Page | Description |
+| --- | --- |
+| [API Guide](api/README) | EzEconomyAPI usage, Vault hook, events, and multi-currency examples |
+| [Custom Storage Providers](api/storage-provider) | Implement your own storage backend |
+| [Testing Guide](testing) | Running tests and JaCoCo coverage reports |
+| [Storage Architecture](storage/storage) | Backend design, data safety, and concurrency model |
+
+## Quick Reference
+
+EzEconomy exposes a versioned public API under `com.skyblockexp.ezeconomy.api`.
+
+### Maven dependency
+
+```xml
+<dependency>
+    <groupId>com.skyblockexp</groupId>
+    <artifactId>ezeconomy-api</artifactId>
+    <version>3.0.0</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+### Basic usage
+
+```java
+StorageProvider storage = EzEconomyAPI.getStorage();
+
+// Deposit funds
+storage.deposit(playerUuid, "dollar", new BigDecimal("100"));
+
+// Get balance
+BigDecimal balance = storage.getBalance(playerUuid, "dollar");
+```
+
+See [API Guide](api/README) for full examples, event listeners, and multi-currency usage.

--- a/docs/feature/caching-strategy.md
+++ b/docs/feature/caching-strategy.md
@@ -1,6 +1,6 @@
 ---
 title: Caching Strategy
-nav_order: 2
+nav_order: 5
 parent: Features
 ---
 

--- a/docs/feature/index.md
+++ b/docs/feature/index.md
@@ -1,6 +1,6 @@
 ---
 title: Features
-nav_order: 11
+nav_order: 9
 has_children: true
 ---
 

--- a/docs/feature/locking-strategy.md
+++ b/docs/feature/locking-strategy.md
@@ -1,6 +1,6 @@
 ---
 title: Locking Strategy
-nav_order: 3
+nav_order: 6
 parent: Features
 ---
 

--- a/docs/feature/money-formatting.md
+++ b/docs/feature/money-formatting.md
@@ -1,6 +1,6 @@
 ---
 title: Money Formatting
-nav_order: 4
+nav_order: 3
 parent: Features
 ---
 

--- a/docs/feature/multi-currency.md
+++ b/docs/feature/multi-currency.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Currency
-nav_order: 5
+nav_order: 2
 parent: Features
 ---
 

--- a/docs/feature/proxy-network.md
+++ b/docs/feature/proxy-network.md
@@ -1,6 +1,6 @@
 ---
 title: Proxy Network
-nav_order: 6
+nav_order: 4
 parent: Features
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ nav_order: 1
 
 # EzEconomy
 
-EzEconomy is a Vault-compatible economy provider built for reliability, clarity,
-and scalability. It supports multiple storage backends, optional multi-currency
-systems, and bank accounts while keeping operations safe under high concurrency.
+EzEconomy is a Vault-compatible economy plugin for Paper/Spigot 1.7.10 – 1.21.1.
+It supports multiple storage backends, optional multi-currency systems, bank accounts,
+and async caching — all designed to keep your economy safe and fast under load.
 
 ## Highlights
 
@@ -18,20 +18,30 @@ systems, and bank accounts while keeping operations safe under high concurrency.
 - **Async caching** — keeps balance lookups fast on busy servers.
 - **Banking system** — shared accounts with member management and permissions.
 
-## Quick Start
+---
 
-1. Install **Vault** and **EzEconomy**.
-2. Place `EzEconomy.jar` in your plugins folder.
-3. Configure `config.yml` and your selected storage config file.
-4. Restart the server to generate data files.
+## For Server Owners & Admins
 
-## Where to Go Next
-
-| Section | Description |
-|:--------|:------------|
-| [Configuration](configuration) | Storage backends, multi-currency, and plugin settings |
-| [Commands](commands) | Player and admin commands |
-| [Permissions](permissions) | Permission nodes for staff and players |
-| [Database](database) | Backend behaviour and data safety |
-| [Developer API](developer-api) | Events, Vault hook, and custom storage providers |
+| | |
+|:---|:---|
+| [Getting Started](overview) | Install EzEconomy, choose a storage backend, verify your setup |
+| [Configuration](configuration) | Storage backends, multi-currency, banking toggle, caching |
+| [Commands](commands) | Player and admin command reference |
+| [Permissions](permissions) | Permission nodes with recommended role assignments |
+| [Storage Backends](database) | Backend setup, table schemas, and backup guidance |
 | [Placeholders](placeholders) | PlaceholderAPI expansion reference |
+| [Moderation Guide](moderation) | Give/take balances, investigate players, cleanup & maintenance |
+
+## Optional Features
+
+| | |
+|:---|:---|
+| [Banking](feature/banking) | Shared bank accounts with member roles |
+| [Multi-Currency](feature/multi-currency) | Multiple currencies with conversion rates |
+| [Integrations](integration/) | Vault, PlaceholderAPI, Redis, BungeeCord |
+
+## For Developers
+
+| | |
+|:---|:---|
+| [Developer Reference](developer-api) | EzEconomyAPI, events, custom storage providers |

--- a/docs/integration/bungeecord.md
+++ b/docs/integration/bungeecord.md
@@ -1,6 +1,6 @@
 ---
 title: BungeeCord
-nav_order: 1
+nav_order: 4
 parent: Integrations
 ---
 

--- a/docs/integration/index.md
+++ b/docs/integration/index.md
@@ -1,6 +1,6 @@
 ---
 title: Integrations
-nav_order: 12
+nav_order: 10
 has_children: true
 ---
 

--- a/docs/integration/vault.md
+++ b/docs/integration/vault.md
@@ -1,6 +1,6 @@
 ---
 title: Vault
-nav_order: 4
+nav_order: 1
 parent: Integrations
 ---
 

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -1,0 +1,155 @@
+---
+title: Moderation Guide
+nav_order: 8
+---
+
+# Moderation Guide
+
+This guide covers the tools and best practices available to server staff for managing the economy — inspecting balances, adjusting funds, investigating reports, and maintaining a healthy in-game economy.
+
+## Required Permission
+
+All economy management commands require `ezeconomy.eco` (or its parent `ezeconomy.admin`).
+Grant this to your admin group only — see [Permissions](permissions) for recommended role setup.
+
+---
+
+## Checking a Player's Balance
+
+```text
+/balance <player>              # Requires: ezeconomy.balance.others
+/balance <player> <currency>   # Check balance in a specific currency
+```
+
+Use this to verify a player's current funds before or after handling a report.
+
+---
+
+## Adjusting Balances
+
+### Give money
+
+```text
+/eco give <player> <amount>
+/eco give <player> <amount> <currency>
+```
+
+Adds funds without removing them from anyone else. Use this for rewards, refunds, or compensations.
+
+### Take money
+
+```text
+/eco take <player> <amount>
+/eco take <player> <amount> <currency>
+```
+
+Deducts funds from a player's balance. If the player has insufficient funds, the command will clamp to zero (or reject, depending on config). Use this for fines, grief reimbursements billed to the responsible party, or rollbacks.
+
+### Set balance
+
+```text
+/eco set <player> <amount>
+/eco set <player> <amount> <currency>
+```
+
+Sets a player's balance to an exact value. Use with caution — this **replaces** the existing balance rather than adjusting it. Avoid using `set` for routine adjustments; prefer `give` / `take` so the change is auditable.
+
+---
+
+## Leaderboard & Investigation
+
+```text
+/baltop           # View top balances — useful for spotting abnormal wealth
+/baltop 20        # Expand the list
+```
+
+A player appearing at the top unexpectedly may indicate duplication, an exploit, or a gifting arrangement. Cross-reference with server logs or plugin audit logs if available.
+
+---
+
+## Bank Moderation
+
+Server admins with `ezeconomy.bank.admin` can inspect and modify any bank:
+
+```text
+/bank info <name>              # View members, owner, and balance
+/bank balance <name>           # Quick balance check
+/bank deposit <name> <amount>  # Add funds to a bank
+/bank withdraw <name> <amount> # Remove funds from a bank
+/bank delete <name>            # Delete an empty or abandoned bank
+/bank removemember <name> <player>  # Remove a player from a bank
+```
+
+---
+
+## Pay-All Command
+
+```text
+/pay * <amount>   # Requires: ezeconomy.payall
+```
+
+Distributes `<amount>` to every online player. By default the total (amount × online count) is withdrawn from the sender first. Admins with `ezeconomy.payall.bypasswithdraw` can distribute funds without deducting from their own balance — useful for events but should be restricted to trusted staff.
+
+---
+
+## Plugin Administration Commands
+
+These require `ezeconomy.admin`:
+
+| Command | What it does |
+| --- | --- |
+| `/ezeconomy reload` | Reloads `config.yml` and message files without a server restart. |
+| `/ezeconomy reload messages` | Reloads only the message/language file. |
+| `/ezeconomy cleanup` | Removes orphaned player data (accounts with no balance in any currency). Run periodically on large servers. |
+| `/ezeconomy daily reset` | Resets all daily reward counters for all players. |
+| `/ezeconomy database info` | Shows the active storage backend and connection details. |
+| `/ezeconomy database test` | Tests the live database connection — useful after config changes. |
+| `/ezeconomy database reset` | **Dangerous.** Drops and recreates all tables. Only use on a fresh install or with a verified backup. |
+
+---
+
+## Common Moderation Scenarios
+
+### A player reports a missing balance
+
+1. Check the balance: `/balance <player>`
+2. Review server logs around the reported time for `/eco` or `/pay` entries.
+3. If confirmed lost: `/eco give <player> <amount>` to restore.
+4. Note the reason in your ticket system or staff logs.
+
+### A player has suspiciously high balance
+
+1. `/balance <player>` — confirm amount.
+2. Check `/baltop` to see if others are similarly affected.
+3. If duplication or exploit is suspected, use `/eco set <player> 0` or a corrected amount.
+4. If needed, roll back from a database backup (see [Storage Backends](database#backups)).
+
+### Economy plugin reloaded but balances look wrong
+
+1. Run `/ezeconomy database test` — confirm the connection is live.
+2. Run `/ezeconomy reload` to re-read config.
+3. If nothing resolves it, check `plugins/EzEconomy/logs/` (if enabled) or server logs for errors.
+
+### Database connection error after config change
+
+1. Run `/ezeconomy database test` to see the error in console.
+2. Double-check credentials in the relevant config file (e.g., `config-mysql.yml`).
+3. Reload with `/ezeconomy reload` after correcting the file.
+
+---
+
+## Performance & Maintenance Tips
+
+- Run `/ezeconomy cleanup` periodically (e.g., weekly) to remove stale accounts and keep the database lean.
+- Schedule **regular backups** before any `database reset` or mass economy event. See [Storage Backends → Backups](database#backups).
+- Avoid running `/eco set` on large numbers of players in quick succession — prefer a script or import if bulk-adjusting balances.
+- On networks with Redis or BungeeCord locking, coordinate `/ezeconomy reload` across all backend servers to avoid cache inconsistencies.
+
+---
+
+## Security Tips
+
+- Grant `ezeconomy.eco` and `ezeconomy.admin` only to **fully trusted staff**. These permissions allow arbitrary balance changes.
+- Restrict `ezeconomy.payall.bypasswithdraw` to server-event organiser accounts, not general admin groups.
+- Log all `/eco` usage via a staff-audit plugin (e.g., CoreProtect, LogBlock, or a Discord logging bot) so actions are traceable.
+- Periodically audit your `/baltop` list for anomalies — large sudden changes may indicate a recently-discovered exploit.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,42 +1,75 @@
 ---
-title: Overview
+title: Getting Started
 nav_order: 2
 ---
 
-# EzEconomy
+# Getting Started
 
-EzEconomy is a Vault-compatible economy provider built for reliability, clarity, and scalability. It supports multiple storage backends, optional multi-currency systems, and bank accounts while keeping operations safe under high concurrency.
+This guide walks you through installing and configuring EzEconomy for the first time.
 
-## Highlights
+## Prerequisites
 
-- **Vault integration**: Works with any Vault-based plugin without extra setup.
-- **Flexible storage**: YML, MySQL, SQLite, MongoDB, or a custom provider.
-- **Multi-currency**: Optional per-player currency selection with conversion rates.
-- **Async caching**: Keeps balance lookups fast on busy servers.
-- **Banking system**: Shared accounts with member management and permissions.
-- **Banking system**: Shared accounts with member management and permissions. You can disable the built-in banking subsystem via `banking.enabled: false` in `config.yml` if you run an external bank plugin or don't need bank features.
+Before installing, make sure you have:
 
-## Supported Versions
+- **Java 8 or higher** — required by your server jar.
+- **Paper or Spigot 1.7.10 – 1.21.1** — EzEconomy supports the full version range.
+- **[Vault](https://www.spigotmc.org/resources/vault.34315/)** — required. EzEconomy registers itself as the Vault economy provider so that shop, job, and reward plugins work automatically.
+- *(Optional)* **[PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/)** — needed for balance placeholders in chat, scoreboards, and other plugins.
 
-EzEconomy targets modern Paper/Spigot servers that support Vault. For best results, use the latest versions of Paper, Vault, and EzEconomy.
+## Installation
 
-## Quick Start
+1. **Download** `EzEconomy.jar` from the [releases page](https://github.com/ez-plugins/EzEconomy/releases).
+2. **Place** `EzEconomy.jar` (and `Vault.jar` if not already present) in your server's `plugins/` folder.
+3. **Start the server** once to generate the default configuration files.
+4. **Stop the server** and edit `plugins/EzEconomy/config.yml` to choose your storage backend and any optional features.
+5. **Start the server** again — EzEconomy will connect to the configured backend and register with Vault.
 
-1. Install **Vault** and **EzEconomy**.
-2. Place `EzEconomy.jar` in your plugins folder.
-3. Configure `config.yml` and your selected storage config file.
-4. Restart the server to generate data files.
+## Choosing a Storage Backend
 
-## Typical Use Cases
+Pick the backend that fits your server's scale and infrastructure:
 
-- Replace legacy economies without changing other plugins.
-- Provide multiple currencies for different game modes.
-- Offer shared bank accounts for guilds or factions.
+| Backend | Best For | Requirements |
+| --- | --- | --- |
+| **YML** *(default)* | Small servers, testing | None — data is written to flat files |
+| **SQLite** | Single server, larger player counts | None — embedded database, no server needed |
+| **MySQL** | Networks, high traffic, shared hosting | Requires a MySQL or MariaDB server |
+| **MongoDB** | Existing MongoDB infrastructure | Requires a MongoDB server |
 
-## Where to Go Next
+Set the `storage` key in `config.yml`, then fill in the matching storage config file (e.g., `config-mysql.yml`):
 
-- **Configuration**: See storage-specific settings and multi-currency setup.
-- **Commands & Permissions**: Confirm staff and player access rules.
-- **Storage Details**: Understand backend behavior and data safety.
+```yaml
+storage: yml   # options: yml, sqlite, mysql, mongodb
+```
 
-- **Events**: EzEconomy now exposes pre/post transaction events for integrations and moderation. See `docs/api/event/PreTransactionEvent.md`, `docs/api/event/PostTransactionEvent.md`, `docs/api/event/PlayerPayPlayerEvent.md`, and `docs/api/event/TransactionType.md` for details and examples.
+See [Storage Backends](storage-backends) for full setup instructions and schema details.
+
+## First-Start Checklist
+
+After the first successful start, verify the following:
+
+1. The server console shows `[EzEconomy] Economy service registered with Vault.`
+2. The folder `plugins/EzEconomy/` contains `config.yml` and the matching storage config file.
+3. Other Vault-dependent plugins (shops, jobs, rewards) recognise EzEconomy as the active economy.
+
+## Quick Verification
+
+Run these commands in-game as a server operator:
+
+```text
+/balance              # Shows your balance (default: 0)
+/eco give <you> 100   # Credit yourself 100
+/balance              # Should now show 100
+```
+
+If `/balance` returns an error, check that Vault is installed and that the console shows the registration message above.
+
+## Next Steps
+
+| I want to… | Go here |
+|:-----------|:--------|
+| Configure storage, currencies, banking, and caching | [Configuration](configuration) |
+| See all player and admin commands | [Commands](commands) |
+| Set up permissions for staff and players | [Permissions](permissions) |
+| Monitor and adjust player economies | [Moderation Guide](moderation) |
+| Show balances in chat or scoreboards | [Placeholders](placeholders) |
+| Enable multi-currency or the bank system | [Features](feature/) |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -5,38 +5,62 @@ nav_order: 5
 
 # Permissions
 
-Assign permissions through your permissions plugin (LuckPerms, PermissionsEx, etc.).
+Assign permissions through your permissions plugin (LuckPerms, PermissionsEx, GroupManager, etc.).
 
 ## Player Permissions
 
-| Permission | Description |
-| --- | --- |
-| `ezeconomy.balance.others` | View other players' balances. |
-| `ezeconomy.pay` | Send payments to other players. |
-| `ezeconomy.currency` | Set or view preferred currency. |
+| Permission | Description | Default |
+| --- | --- | --- |
+| `ezeconomy.balance` | View own balance with `/balance`. | everyone |
+| `ezeconomy.balance.others` | View another player's balance. | op |
+| `ezeconomy.pay` | Send money to another player with `/pay`. | everyone |
+| `ezeconomy.payall` | Use `/pay * <amount>` to pay all online players. | op |
+| `ezeconomy.currency` | View or change preferred currency with `/currency`. | everyone |
+| `ezeconomy.baltop` | View the top-balance list with `/baltop`. | everyone |
 
 ## Administrative Permissions
 
-| Permission | Description |
-| --- | --- |
-| `ezeconomy.eco` | Use `/eco` to give, take, or set balances. |
-| `ezeconomy.bank.admin` | Grants all bank-related permissions. |
+| Permission | Description | Default |
+| --- | --- | --- |
+| `ezeconomy.eco` | Use `/eco give`, `/eco take`, `/eco set` to manage balances. | op |
+| `ezeconomy.admin` | Run all `/ezeconomy` subcommands (reload, cleanup, database). | op |
+| `ezeconomy.payall.bypasswithdraw` | Use `/pay *` without funds being withdrawn from the sender. | op |
 
 ## Bank Permissions
 
 | Permission | Description |
 | --- | --- |
-| `ezeconomy.bank.create` | Create a bank. |
-| `ezeconomy.bank.delete` | Delete a bank. |
-| `ezeconomy.bank.balance` | View bank balance. |
-| `ezeconomy.bank.deposit` | Deposit to a bank. |
+| `ezeconomy.bank.create` | Create a bank account. |
+| `ezeconomy.bank.delete` | Delete a bank account. |
+| `ezeconomy.bank.balance` | View a bank's balance. |
+| `ezeconomy.bank.deposit` | Deposit into a bank. |
 | `ezeconomy.bank.withdraw` | Withdraw from a bank. |
-| `ezeconomy.bank.addmember` | Add a bank member. |
-| `ezeconomy.bank.removemember` | Remove a bank member. |
-| `ezeconomy.bank.info` | View bank info. |
+| `ezeconomy.bank.addmember` | Add a member to a bank. |
+| `ezeconomy.bank.removemember` | Remove a member from a bank. |
+| `ezeconomy.bank.info` | View a bank's member list and details. |
+| `ezeconomy.bank.admin` | Grants all `ezeconomy.bank.*` permissions. |
 
-## Recommended Roles
+## Recommended Role Setup
 
-- **Players**: `ezeconomy.pay`, `ezeconomy.currency`
-- **Staff**: `ezeconomy.balance.others`
-- **Administrators**: `ezeconomy.eco`, `ezeconomy.bank.admin`
+| Role | Permissions to grant |
+| --- | --- |
+| **Player** | `ezeconomy.pay`, `ezeconomy.currency`, `ezeconomy.baltop`, `ezeconomy.bank.balance`, `ezeconomy.bank.deposit`, `ezeconomy.bank.withdraw`, `ezeconomy.bank.info` |
+| **Moderator** | All player permissions + `ezeconomy.balance.others` |
+| **Admin** | All moderator permissions + `ezeconomy.eco`, `ezeconomy.admin`, `ezeconomy.bank.admin`, `ezeconomy.payall` |
+
+## LuckPerms Example
+
+```bash
+# Grant the default player group economy access
+lp group default permission set ezeconomy.pay true
+lp group default permission set ezeconomy.currency true
+lp group default permission set ezeconomy.baltop true
+
+# Grant moderators balance inspection
+lp group moderator permission set ezeconomy.balance.others true
+
+# Grant admins full economy control
+lp group admin permission set ezeconomy.eco true
+lp group admin permission set ezeconomy.admin true
+lp group admin permission set ezeconomy.bank.admin true
+```

--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -1,6 +1,6 @@
 ---
 title: Placeholders
-nav_order: 8
+nav_order: 7
 ---
 
 # Placeholders

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -1,6 +1,7 @@
 ---
-title: Storage
-nav_order: 10
+title: Storage Architecture
+nav_order: 4
+parent: Developer Reference
 ---
 
 # Storage & Data Safety

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,7 @@
 ---
 title: Testing
-nav_order: 9
+nav_order: 3
+parent: Developer Reference
 ---
 
 # Testing Guidelines for EzEconomy


### PR DESCRIPTION
Navigation changes:
- Overview (nav_order 2) repurposed as 'Getting Started' with proper install prerequisites, backend selection table, checklist, and next-steps
- Database → renamed to 'Storage Backends' (nav_order 6)
- Placeholders moved to nav_order 7
- New Moderation Guide at nav_order 8
- Features section moved to nav_order 9; children reordered so Banking (1), Multi-Currency (2), Money Formatting (3), Proxy Network (4), Caching Strategy (5), Locking Strategy (6)
- Integrations moved to nav_order 10; Vault promoted to nav_order 1 (most important), BungeeCord moved to nav_order 4
- Developer Reference at nav_order 11 (was a redirect stub); now a proper has_children parent page with quick-reference snippet
- Testing and Storage Architecture moved to children of Developer Reference
- All api/ files gain front matter; api/README is 'API Guide' child of Developer Reference with has_children; all six event docs become grandchildren (parent: API Guide, grand_parent: Developer Reference)

Content improvements:
- Home (index.md): split navigation into 'For Server Owners', 'Optional Features', and 'For Developers' sections
- Permissions: added ezeconomy.admin, ezeconomy.payall, ezeconomy.payall.bypasswithdraw, Default column, Recommended Role table, and a LuckPerms bash example block
- Storage Backends (database.md): aligned H1 with nav title; appended full Backups section (YML/SQLite/MySQL/MongoDB and restore procedure)
- Developer Reference (developer-api.md): full rewrite as parent landing page with Maven dependency and basic API usage snippet

New file:
- docs/moderation.md: Moderation Guide covering balance inspection, eco give/take/set, bank admin commands, /ezeconomy admin commands, common moderation scenarios (missing balance, suspicious wealth, connection errors), and security tips