### PR TITLE
ci: add release/nightly workflows and [Unreleased] CHANGELOG section

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,11 +1,11 @@
-# Publishes Maven packages to GitHub Packages and releases the plugin to Modrinth
-# when a GitHub release is created.
+# DEPRECATED: Superseded by release.yml (tag-triggered) and nightly.yml.
+# Kept as a manual fallback only. Do NOT re-enable the release: [created] trigger
+# as it would conflict with release.yml which creates the GitHub Release itself.
 
-name: Maven Package
+name: Maven Package (Legacy)
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,214 @@
+name: Nightly Build
+
+# Runs every day at 04:00 UTC, or can be triggered manually.
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    name: Nightly Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create nightly tag & GitHub prerelease
+      packages: write   # not published on nightly, kept for consistency
+
+    steps:
+      # ──────────────────────────────────────────────────────────────────────
+      #  1. CHECKOUT
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  2. CHECK FOR UNRELEASED CHANGES
+      #
+      #  Skip the nightly if the only commits since the last tag are from bots.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Check for unreleased non-bot changes
+        id: changes
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [[ -z "$LAST_TAG" ]]; then
+            echo "No tags found; will proceed with nightly."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            # Count commits since last tag that are NOT from github-actions[bot].
+            COUNT=$(git log "${LAST_TAG}..HEAD" \
+              --oneline \
+              --perl-regexp \
+              --author='^(?!github-actions\[bot\])' \
+              | wc -l | tr -d ' ')
+            echo "Non-bot commits since ${LAST_TAG}: ${COUNT}"
+            if [[ "$COUNT" -gt 0 ]]; then
+              echo "has_changes=true"  >> "$GITHUB_OUTPUT"
+            else
+              echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Skip if no unreleased changes
+        if: steps.changes.outputs.has_changes == 'false'
+        run: |
+          echo "No unreleased changes from non-bot authors. Skipping nightly."
+          exit 0
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  3. COMPUTE NIGHTLY VERSION
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Compute nightly version
+        id: meta
+        run: |
+          # Base: strip -SNAPSHOT from the version in the root pom.xml.
+          BASE=$(mvn -q -ntp help:evaluate -Dexpression=project.version -DforceStdout \
+            | sed 's/-SNAPSHOT//')
+          DATE=$(date -u +'%Y%m%d')
+          VERSION="${BASE}-nightly.${DATE}"
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}"         >> "$GITHUB_OUTPUT"
+          echo "Nightly version: ${VERSION}"
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  4. BUILD
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Set nightly version in all POMs
+        run: |
+          mvn -B -ntp versions:set \
+            -DnewVersion="${{ steps.meta.outputs.version }}" \
+            -DprocessAllModules \
+            -DgenerateBackupPoms=false
+
+      # Tests are skipped to avoid requiring MockBukkit built from source.
+      - name: Build
+        run: mvn -B -ntp -Dmaven.test.skip=true package
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  5. EXTRACT UNRELEASED CHANGELOG SECTION
+      #
+      #  Reads everything under "## [Unreleased]" up to the next "## [" line.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Extract [Unreleased] changelog section
+        id: changelog
+        run: |
+          NOTES=$(awk \
+            '/^## \[Unreleased\]/ { p=1; next }
+             /^## \[/ && p      { exit }
+             p                  { print }' \
+            CHANGELOG.md \
+            | sed '/^[[:space:]]*$/d' \
+            | head -n 60)
+
+          if [[ -z "$NOTES" ]]; then
+            NOTES="Nightly snapshot build. No unreleased notes in CHANGELOG.md yet."
+          fi
+
+          printf '%s\n' "$NOTES" > release-notes.md
+          echo "=== Nightly release notes ===" && cat release-notes.md
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  6. MODRINTH BETA RELEASE
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Release to Modrinth (beta)
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: ezeconomy
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          modrinth-featured: false
+          name: "EzEconomy ${{ steps.meta.outputs.version }}"
+          version: "${{ steps.meta.outputs.version }}"
+          version-type: beta
+          files: |
+            ezeconomy-bukkit/target/ezeconomy-bukkit-${{ steps.meta.outputs.version }}.jar
+            ezeconomy-papi/target/ezeconomy-papi-${{ steps.meta.outputs.version }}.jar
+            ezeconomy-redis/target/ezeconomy-redis-${{ steps.meta.outputs.version }}.jar
+            ezeconomy-bungeecord/target/ezeconomy-bungeecord-${{ steps.meta.outputs.version }}.jar
+            ezeconomy-bungeecord-proxy/target/ezeconomy-bungeecord-proxy-${{ steps.meta.outputs.version }}.jar
+          game-versions: ">=1.7.10"
+          game-versions-filter: release
+          loaders: |
+            bukkit
+            spigot
+            paper
+            purpur
+            folia
+          changelog-file: release-notes.md
+          dependencies: |
+            placeholderapi(optional)
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  7. CREATE NIGHTLY TAG & GITHUB PRE-RELEASE
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Configure git for tag push
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push nightly tag
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          TAG="${{ steps.meta.outputs.tag }}"
+          gh release create "$TAG" \
+            --title "EzEconomy ${VERSION}" \
+            --notes-file release-notes.md \
+            --prerelease \
+            "ezeconomy-bukkit/target/ezeconomy-bukkit-${VERSION}.jar" \
+            "ezeconomy-papi/target/ezeconomy-papi-${VERSION}.jar" \
+            "ezeconomy-redis/target/ezeconomy-redis-${VERSION}.jar" \
+            "ezeconomy-bungeecord/target/ezeconomy-bungeecord-${VERSION}.jar" \
+            "ezeconomy-bungeecord-proxy/target/ezeconomy-bungeecord-proxy-${VERSION}.jar"
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  8. DISCORD NOTIFICATION
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Post Discord notification
+        if: ${{ secrets.EZECONOMY_RELEASE_DISCORD_WEBHOOK != '' }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.EZECONOMY_RELEASE_DISCORD_WEBHOOK }}
+        run: |
+          REPO="${{ github.repository }}"
+          VERSION="${{ steps.meta.outputs.version }}"
+          TAG="${{ steps.meta.outputs.tag }}"
+          GH_URL="https://github.com/${REPO}/releases/tag/${TAG}"
+
+          CHANGELOG=$(head -c 3800 release-notes.md || true)
+
+          PAYLOAD=$(jq -n \
+            --arg version "$VERSION" \
+            --arg gh_url  "$GH_URL" \
+            --arg log     "$CHANGELOG" \
+            '{
+              embeds: [{
+                title:       ("🌙 EzEconomy " + $version + " — Nightly Build"),
+                url:         $gh_url,
+                color:       10181046,
+                description: $log,
+                fields: [
+                  { name: "GitHub Release", value: ("[View on GitHub](" + $gh_url + ")"), inline: true }
+                ],
+                footer: { text: "EzEconomy · Nightly Build" }
+              }]
+            }')
+
+          curl --fail -s -X POST "$DISCORD_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,208 @@
+name: Stable Release
+
+# Fires when a vX.Y.Z tag is pushed, or can be triggered manually with a tag.
+on:
+  push:
+    tags:
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v3.0.3)'
+        required: true
+
+jobs:
+  release:
+    name: Stable Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create GitHub release & push tag
+      packages: write   # publish to GitHub Packages
+
+    steps:
+      # ──────────────────────────────────────────────────────────────────────
+      #  1. CHECKOUT
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  2. RESOLVE VERSION
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Resolve version from tag
+        id: meta
+        run: |
+          REF="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${REF#v}"
+          echo "ref=${REF}"         >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: ${VERSION}"
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  3. CREATE TAG (if it doesn't exist yet)
+      #
+      #  When triggered via workflow_dispatch the tag may not exist yet.
+      #  This step creates and pushes it so the GitHub Release can reference it.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Create and push tag if missing
+        run: |
+          REF="${{ steps.meta.outputs.ref }}"
+          if git rev-parse --verify --quiet "refs/tags/${REF}" > /dev/null; then
+            echo "Tag ${REF} already exists; skipping creation."
+          else
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${REF}"
+            git push origin "${REF}"
+            echo "Created and pushed tag ${REF}."
+          fi
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  4. BUILD
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Set release version in all POMs
+        run: |
+          mvn -B -ntp versions:set \
+            -DnewVersion="${{ steps.meta.outputs.version }}" \
+            -DprocessAllModules \
+            -DgenerateBackupPoms=false
+
+      # Tests are skipped (maven.test.skip=true) to avoid requiring MockBukkit
+      # to be built from source, which is only needed for test compilation.
+      - name: Build
+        run: mvn -B -ntp -Dmaven.test.skip=true package
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  5. EXTRACT CHANGELOG
+      #
+      #  Reads the section for this version from CHANGELOG.md.
+      #  Falls back gracefully when the section is missing.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          HEADER="## [${VERSION}]"
+
+          # Fixed-string match via index() avoids regex issues with dots in versions.
+          NOTES=$(awk \
+            -v hdr="$HEADER" \
+            '/^## \[/ && p { exit }
+             index($0, hdr) == 1 { p=1; next }
+             p { print }' \
+            CHANGELOG.md)
+
+          if [[ -z "$NOTES" ]]; then
+            NOTES="No changelog entry found for ${VERSION}. See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for full history."
+          fi
+
+          printf '%s\n' "$NOTES" > release-notes.md
+          echo "=== Release notes preview ===" && cat release-notes.md
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  6. GITHUB RELEASE
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          gh release create "${{ steps.meta.outputs.ref }}" \
+            --title "EzEconomy ${VERSION}" \
+            --notes-file release-notes.md \
+            "ezeconomy-bukkit/target/ezeconomy-bukkit-${VERSION}.jar" \
+            "ezeconomy-papi/target/ezeconomy-papi-${VERSION}.jar" \
+            "ezeconomy-redis/target/ezeconomy-redis-${VERSION}.jar" \
+            "ezeconomy-bungeecord/target/ezeconomy-bungeecord-${VERSION}.jar" \
+            "ezeconomy-bungeecord-proxy/target/ezeconomy-bungeecord-proxy-${VERSION}.jar"
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  7. GITHUB PACKAGES
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Publish to GitHub Packages
+        continue-on-error: true   # don't fail if the version already exists
+        run: mvn -B -ntp -Dmaven.test.skip=true deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  8. MODRINTH RELEASE
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Release to Modrinth (stable)
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          modrinth-id: ezeconomy
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          modrinth-featured: true
+          name: "EzEconomy ${{ steps.meta.outputs.version }}"
+          version: "${{ steps.meta.outputs.version }}"
+          version-type: release
+          files: |
+            ezeconomy-bukkit/target/ezeconomy-bukkit-${{ steps.meta.outputs.version }}.jar
+            ezeconomy-papi/target/ezeconomy-papi-${{ steps.meta.outputs.version }}.jar
+            ezeconomy-redis/target/ezeconomy-redis-${{ steps.meta.outputs.version }}.jar
+            ezeconomy-bungeecord/target/ezeconomy-bungeecord-${{ steps.meta.outputs.version }}.jar
+            ezeconomy-bungeecord-proxy/target/ezeconomy-bungeecord-proxy-${{ steps.meta.outputs.version }}.jar
+          game-versions: ">=1.7.10"
+          game-versions-filter: release
+          loaders: |
+            bukkit
+            spigot
+            paper
+            purpur
+            folia
+          changelog-file: release-notes.md
+          dependencies: |
+            placeholderapi(optional)
+
+      # ──────────────────────────────────────────────────────────────────────
+      #  9. DISCORD NOTIFICATION
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Post Discord notification
+        if: ${{ secrets.EZECONOMY_RELEASE_DISCORD_WEBHOOK != '' }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.EZECONOMY_RELEASE_DISCORD_WEBHOOK }}
+        run: |
+          REPO="${{ github.repository }}"
+          VERSION="${{ steps.meta.outputs.version }}"
+          REF="${{ steps.meta.outputs.ref }}"
+          GH_URL="https://github.com/${REPO}/releases/tag/${REF}"
+          MODRINTH_URL="https://modrinth.com/plugin/ezeconomy/version/${VERSION}"
+
+          # Truncate changelog to fit Discord embed description limit (4096 chars).
+          CHANGELOG=$(head -c 3800 release-notes.md || true)
+
+          PAYLOAD=$(jq -n \
+            --arg version "$VERSION" \
+            --arg gh_url  "$GH_URL" \
+            --arg mr_url  "$MODRINTH_URL" \
+            --arg log     "$CHANGELOG" \
+            '{
+              embeds: [{
+                title:       ("🚀 EzEconomy " + $version + " — Stable Release"),
+                url:         $gh_url,
+                color:       3447003,
+                description: $log,
+                fields: [
+                  { name: "GitHub Release", value: ("[View on GitHub]("      + $gh_url + ")"), inline: true },
+                  { name: "Modrinth",       value: ("[Download on Modrinth](" + $mr_url  + ")"), inline: true }
+                ],
+                footer: { text: "EzEconomy · Stable Release" }
+              }]
+            }')
+
+          curl --fail -s -X POST "$DISCORD_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 All notable changes to EzEconomy are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Release tags use the `v` prefix (e.g. `v3.0.3`).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
 
 ---
 


### PR DESCRIPTION
- Add .github/workflows/release.yml: tag-triggered stable release (vX.Y.Z push or workflow_dispatch), builds all 5 modules, extracts changelog section from CHANGELOG.md, creates GitHub Release + JARs, publishes to GitHub Packages & Modrinth stable, posts Discord embed
- Add .github/workflows/nightly.yml: daily 04:00 UTC pre-release, skips if only bot commits since last tag, computes BASE-nightly.YYYYMMDD version, extracts [Unreleased] from CHANGELOG.md, Modrinth beta, GitHub prerelease, Discord embed
- Deprecate maven-publish.yml release trigger (changed to workflow_dispatch only) to prevent conflict with release.yml creating the GitHub Release
- Add [Unreleased] skeleton + format header to CHANGELOG.md for nightly awk