### PR TITLE
fix: resolve cross-server player UUID for payments

### DIFF
--- a/src/main/java/com/skyblockexp/ezeconomy/command/PayCommand.java
+++ b/src/main/java/com/skyblockexp/ezeconomy/command/PayCommand.java
@@ -232,7 +232,6 @@ public class PayCommand implements CommandExecutor {
         if (online != null) {
             knownOffline = true;
         } else {
-            // Use PlayerLookup to avoid expensive or blocking lookups.
             var maybe = com.skyblockexp.ezeconomy.util.PlayerLookup.findByName(operands[0]);
             if (maybe.isPresent()) {
                 OfflinePlayer sample = maybe.get();
@@ -247,8 +246,20 @@ public class PayCommand implements CommandExecutor {
                                 knownOffline = true;
                             }
                         }
-                    } catch (Exception ignored) {
-                        // swallow and treat as unknown
+                    } catch (Exception ignored) {}
+                }
+            }
+            if (!knownOffline) {
+                com.skyblockexp.ezeconomy.messaging.MessagingService ms = plugin.getMessagingService();
+                if (ms != null && ms.isNetworkPlayer(operands[0])) {
+                    knownOffline = true;
+                } else {
+                    var storage = plugin.getStorageOrWarn();
+                    if (storage != null) {
+                        UUID resolved = storage.resolvePlayerByName(operands[0]);
+                        if (resolved != null) {
+                            knownOffline = true;
+                        }
                     }
                 }
             }

--- a/src/main/java/com/skyblockexp/ezeconomy/service/PaymentExecutor.java
+++ b/src/main/java/com/skyblockexp/ezeconomy/service/PaymentExecutor.java
@@ -31,18 +31,37 @@ public class PaymentExecutor {
         if (storage == null) return true;
         plugin.getLogger().info("PaymentExecutor: start execute from=" + from.getName() + " toName=" + toName + " amount=" + netAmount + " currency=" + currency + " knownOffline=" + knownOffline);
 
-        // Try online fast path
         Player online = Bukkit.getPlayerExact(toName);
-        OfflinePlayer toOffline = online != null ? online : Bukkit.getOfflinePlayer(toName);
+        OfflinePlayer toOffline = online != null ? online : null;
 
         UUID fromUuid = from.getUniqueId();
 
-        // If recipient is not online and not known to the server, treat as not found.
-        if (online == null && !knownOffline) {
-            // If OfflinePlayer has played before, consider known
-            boolean hasPlayed = toOffline != null && toOffline.hasPlayedBefore();
-            plugin.getLogger().info("PaymentExecutor: recipient online=null knownOffline=false toOffline=" + (toOffline!=null) + " hasPlayedBefore=" + hasPlayed);
-            if (toOffline == null || !hasPlayed) {
+        if (online == null) {
+            // Try local Bukkit lookup first
+            OfflinePlayer localOffline = Bukkit.getOfflinePlayer(toName);
+            if (localOffline != null && localOffline.hasPlayedBefore()) {
+                toOffline = localOffline;
+            }
+
+            // If not found locally, resolve from shared database or messaging service
+            if (toOffline == null && knownOffline) {
+                UUID resolvedUuid = null;
+                com.skyblockexp.ezeconomy.messaging.MessagingService ms = plugin.getMessagingService();
+                if (ms != null) {
+                    resolvedUuid = ms.getNetworkPlayerUuid(toName);
+                }
+                if (resolvedUuid == null) {
+                    StorageProvider storageForResolve = plugin.getStorageOrWarn();
+                    if (storageForResolve != null) {
+                        resolvedUuid = storageForResolve.resolvePlayerByName(toName);
+                    }
+                }
+                if (resolvedUuid != null) {
+                    toOffline = Bukkit.getOfflinePlayer(resolvedUuid);
+                }
+            }
+
+            if (toOffline == null) {
                 plugin.getLogger().info("PaymentExecutor: recipient not found, aborting");
                 MessageUtils.send(from, plugin, "player_not_found");
                 return true;

--- a/src/main/java/com/skyblockexp/ezeconomy/storage/MySQLStorageProvider.java
+++ b/src/main/java/com/skyblockexp/ezeconomy/storage/MySQLStorageProvider.java
@@ -1132,6 +1132,42 @@ public class MySQLStorageProvider implements StorageProvider {
         }
     }
 
+    @Override
+    public UUID resolvePlayerByName(String name) {
+        if (name == null) return null;
+        synchronized (lock) {
+            try {
+                if (playerRepo == null) return null;
+                java.util.List<PlayerModel> results = playerRepo.query(
+                        PlayerModel.queryBuilder()
+                                .whereEquals("name", name)
+                                .limit(1)
+                                .build());
+                if (!results.isEmpty()) {
+                    try {
+                        return UUID.fromString(results.get(0).getId());
+                    } catch (IllegalArgumentException ignored) {}
+                }
+            } catch (StorageException e) {
+                plugin.getLogger().warning("[EzEconomy] MySQL resolvePlayerByName failed for '" + name + "': " + e.getMessage());
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void persistPlayerInfo(UUID uuid, String name, String displayName) {
+        if (uuid == null || name == null) return;
+        synchronized (lock) {
+            try {
+                if (playerRepo == null) return;
+                playerRepo.save(PlayerModel.create(uuid, name, displayName != null ? displayName : name));
+            } catch (StorageException e) {
+                plugin.getLogger().warning("[EzEconomy] MySQL persistPlayerInfo failed for " + uuid + ": " + e.getMessage());
+            }
+        }
+    }
+
     public java.util.Set<String> previewOrphanedPlayers() {
         java.util.Set<String> orphaned = new java.util.HashSet<>();
         synchronized (lock) {


### PR DESCRIPTION
## Summary

- **PayCommand**: after local player lookup fails, now checks `MessagingService.isNetworkPlayer()` and `storage.resolvePlayerByName()` to find recipients on other backend servers
- **PaymentExecutor**: resolves the recipient UUID from the messaging service or shared database instead of `Bukkit.getOfflinePlayer(name)`, which generates an incorrect offline-mode UUID for players unknown to the local server
- **MySQLStorageProvider**: implements `resolvePlayerByName()` by querying the `players` table, and `persistPlayerInfo()` for explicit player data upserts

## Root cause

Cross-server `/pay` failed silently because the recipient was looked up only in Bukkit's local player cache. Players who had never joined the sender's specific server were treated as "not found", even though they existed in the shared MySQL database and were visible to the messaging service.

## Test plan

- [ ] `/pay <player>` works when recipient is on a different backend server
- [ ] `/pay <player>` still works for local online players
- [ ] `/pay <player>` works for offline players who have been on the local server before
- [ ] Cross-server payment notification is delivered to the recipient