### PR TITLE
release: v3.1.1 - cross-server payment fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Release tags use the `v` prefix (e.g. `v3.0.3`).
 
 ---
 
+## [3.1.1] - 2026-05-28
+
+### Fixed
+- **Cross-server `/pay` failing silently** - Payments to players on other backend servers failed because the recipient was looked up only in Bukkit's local player cache. `PayCommand` now checks `MessagingService.isNetworkPlayer()` and `StorageProvider.resolvePlayerByName()` when local lookups fail.
+- **Incorrect UUID for cross-server recipients** - `PaymentExecutor` was using `Bukkit.getOfflinePlayer(name)` which generates an offline-mode UUID for players who have never joined the local server. It now resolves the correct UUID from the messaging service or shared database.
+- **`MySQLStorageProvider.resolvePlayerByName()` not implemented** - The default no-op from the `StorageProvider` interface was being used. Now queries the `players` table by name to return the correct UUID.
+
+### Added
+- `MySQLStorageProvider.persistPlayerInfo()` implementation for explicit player data upserts.
+
+---
+
 ## [3.1.0] - 2026-05-27
 
 ![Bungeecord and Velocity support](https://i.ibb.co/cXcFX7g9/velocity-and-bungeecord.png)

--- a/docs/api/storage-provider.md
+++ b/docs/api/storage-provider.md
@@ -156,12 +156,12 @@ This section documents all methods of the `StorageProvider` interface. Implement
 
 ## Cross-Server Support (v3.1.0+)
 
-These default methods support cross-server payment notifications. Override them if your backend stores player data or pending messages.
+These default methods support cross-server payment notifications. Override them if your backend stores player data or pending messages. As of v3.1.1, `resolvePlayerByName()` and `persistPlayerInfo()` are fully implemented in the MySQL storage provider and are used by `PayCommand` and `PaymentExecutor` for cross-server player resolution.
 
 - `UUID resolvePlayerByName(String name)`  
-  Look up a player UUID by name. Default: returns null.
+  Look up a player UUID by name from the shared database. Used by `PayCommand` when the recipient is not found in Bukkit's local player cache. Default: returns null. MySQL implementation queries the `players` table.
 - `void persistPlayerInfo(UUID uuid, String name, String displayName)`  
-  Store a player's UUID, name, and display name on join. Default: no-op.
+  Store a player's UUID, name, and display name. Called on join and during cross-server lookups. Default: no-op. MySQL implementation upserts into the `players` table.
 - `void insertPendingNotification(UUID targetUuid, String message)`  
   Store a notification for an offline player. Default: no-op.
 - `List<String> pollPendingNotifications(UUID targetUuid)`  

--- a/docs/feature/cross-server.md
+++ b/docs/feature/cross-server.md
@@ -6,7 +6,7 @@ parent: Features
 
 # Cross-Server Messaging
 
-EzEconomy v3.1.0 introduces a unified cross-server messaging layer that handles payment notifications, player list synchronisation, and pending offline notifications across multiple backend servers.
+EzEconomy v3.1.0 introduced a unified cross-server messaging layer that handles payment notifications, player list synchronisation, and pending offline notifications across multiple backend servers. v3.1.1 fixes cross-server `/pay` resolution so that payments work correctly when the recipient has never joined the sender's server.
 
 ## Available Transports
 

--- a/ezeconomy-bukkit/pom.xml
+++ b/ezeconomy-bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>ezeconomy-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>ezeconomy-bukkit</artifactId>

--- a/ezeconomy-bungeecord-proxy/pom.xml
+++ b/ezeconomy-bungeecord-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>ezeconomy-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>ezeconomy-bungeecord-proxy</artifactId>

--- a/ezeconomy-bungeecord/pom.xml
+++ b/ezeconomy-bungeecord/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>ezeconomy-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>ezeconomy-bungeecord</artifactId>

--- a/ezeconomy-papi/pom.xml
+++ b/ezeconomy-papi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>ezeconomy-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/ezeconomy-redis/pom.xml
+++ b/ezeconomy-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>ezeconomy-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>ezeconomy-redis</artifactId>

--- a/ezeconomy-velocity/pom.xml
+++ b/ezeconomy-velocity/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>ezeconomy-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
     </parent>
     <artifactId>ezeconomy-velocity</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>ezeconomy-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <packaging>pom</packaging>
     <name>EzEconomy</name>
     <description>Vault-compatible economy provider with YML and MySQL support</description>

--- a/src/main/java/com/skyblockexp/ezeconomy/command/PayCommand.java
+++ b/src/main/java/com/skyblockexp/ezeconomy/command/PayCommand.java
@@ -232,7 +232,6 @@ public class PayCommand implements CommandExecutor {
         if (online != null) {
             knownOffline = true;
         } else {
-            // Use PlayerLookup to avoid expensive or blocking lookups.
             var maybe = com.skyblockexp.ezeconomy.util.PlayerLookup.findByName(operands[0]);
             if (maybe.isPresent()) {
                 OfflinePlayer sample = maybe.get();
@@ -247,8 +246,20 @@ public class PayCommand implements CommandExecutor {
                                 knownOffline = true;
                             }
                         }
-                    } catch (Exception ignored) {
-                        // swallow and treat as unknown
+                    } catch (Exception ignored) {}
+                }
+            }
+            if (!knownOffline) {
+                com.skyblockexp.ezeconomy.messaging.MessagingService ms = plugin.getMessagingService();
+                if (ms != null && ms.isNetworkPlayer(operands[0])) {
+                    knownOffline = true;
+                } else {
+                    var storage = plugin.getStorageOrWarn();
+                    if (storage != null) {
+                        UUID resolved = storage.resolvePlayerByName(operands[0]);
+                        if (resolved != null) {
+                            knownOffline = true;
+                        }
                     }
                 }
             }

--- a/src/main/java/com/skyblockexp/ezeconomy/service/PaymentExecutor.java
+++ b/src/main/java/com/skyblockexp/ezeconomy/service/PaymentExecutor.java
@@ -37,14 +37,12 @@ public class PaymentExecutor {
         UUID fromUuid = from.getUniqueId();
 
         if (online == null) {
-            // Try local Bukkit lookup first
             OfflinePlayer localOffline = Bukkit.getOfflinePlayer(toName);
-            if (localOffline != null && localOffline.hasPlayedBefore()) {
-                toOffline = localOffline;
-            }
+            boolean localKnown = localOffline != null && localOffline.hasPlayedBefore();
 
-            // If not found locally, resolve from shared database or messaging service
-            if (toOffline == null && knownOffline) {
+            if (localKnown) {
+                toOffline = localOffline;
+            } else if (knownOffline) {
                 UUID resolvedUuid = null;
                 com.skyblockexp.ezeconomy.messaging.MessagingService ms = plugin.getMessagingService();
                 if (ms != null) {
@@ -58,6 +56,8 @@ public class PaymentExecutor {
                 }
                 if (resolvedUuid != null) {
                     toOffline = Bukkit.getOfflinePlayer(resolvedUuid);
+                } else {
+                    toOffline = localOffline;
                 }
             }
 

--- a/src/main/java/com/skyblockexp/ezeconomy/service/PaymentExecutor.java
+++ b/src/main/java/com/skyblockexp/ezeconomy/service/PaymentExecutor.java
@@ -31,18 +31,37 @@ public class PaymentExecutor {
         if (storage == null) return true;
         plugin.getLogger().info("PaymentExecutor: start execute from=" + from.getName() + " toName=" + toName + " amount=" + netAmount + " currency=" + currency + " knownOffline=" + knownOffline);
 
-        // Try online fast path
         Player online = Bukkit.getPlayerExact(toName);
-        OfflinePlayer toOffline = online != null ? online : Bukkit.getOfflinePlayer(toName);
+        OfflinePlayer toOffline = online != null ? online : null;
 
         UUID fromUuid = from.getUniqueId();
 
-        // If recipient is not online and not known to the server, treat as not found.
-        if (online == null && !knownOffline) {
-            // If OfflinePlayer has played before, consider known
-            boolean hasPlayed = toOffline != null && toOffline.hasPlayedBefore();
-            plugin.getLogger().info("PaymentExecutor: recipient online=null knownOffline=false toOffline=" + (toOffline!=null) + " hasPlayedBefore=" + hasPlayed);
-            if (toOffline == null || !hasPlayed) {
+        if (online == null) {
+            // Try local Bukkit lookup first
+            OfflinePlayer localOffline = Bukkit.getOfflinePlayer(toName);
+            if (localOffline != null && localOffline.hasPlayedBefore()) {
+                toOffline = localOffline;
+            }
+
+            // If not found locally, resolve from shared database or messaging service
+            if (toOffline == null && knownOffline) {
+                UUID resolvedUuid = null;
+                com.skyblockexp.ezeconomy.messaging.MessagingService ms = plugin.getMessagingService();
+                if (ms != null) {
+                    resolvedUuid = ms.getNetworkPlayerUuid(toName);
+                }
+                if (resolvedUuid == null) {
+                    StorageProvider storageForResolve = plugin.getStorageOrWarn();
+                    if (storageForResolve != null) {
+                        resolvedUuid = storageForResolve.resolvePlayerByName(toName);
+                    }
+                }
+                if (resolvedUuid != null) {
+                    toOffline = Bukkit.getOfflinePlayer(resolvedUuid);
+                }
+            }
+
+            if (toOffline == null) {
                 plugin.getLogger().info("PaymentExecutor: recipient not found, aborting");
                 MessageUtils.send(from, plugin, "player_not_found");
                 return true;

--- a/src/main/java/com/skyblockexp/ezeconomy/storage/MySQLStorageProvider.java
+++ b/src/main/java/com/skyblockexp/ezeconomy/storage/MySQLStorageProvider.java
@@ -1132,6 +1132,42 @@ public class MySQLStorageProvider implements StorageProvider {
         }
     }
 
+    @Override
+    public UUID resolvePlayerByName(String name) {
+        if (name == null) return null;
+        synchronized (lock) {
+            try {
+                if (playerRepo == null) return null;
+                java.util.List<PlayerModel> results = playerRepo.query(
+                        PlayerModel.queryBuilder()
+                                .whereEquals("name", name)
+                                .limit(1)
+                                .build());
+                if (!results.isEmpty()) {
+                    try {
+                        return UUID.fromString(results.get(0).getId());
+                    } catch (IllegalArgumentException ignored) {}
+                }
+            } catch (StorageException e) {
+                plugin.getLogger().warning("[EzEconomy] MySQL resolvePlayerByName failed for '" + name + "': " + e.getMessage());
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void persistPlayerInfo(UUID uuid, String name, String displayName) {
+        if (uuid == null || name == null) return;
+        synchronized (lock) {
+            try {
+                if (playerRepo == null) return;
+                playerRepo.save(PlayerModel.create(uuid, name, displayName != null ? displayName : name));
+            } catch (StorageException e) {
+                plugin.getLogger().warning("[EzEconomy] MySQL persistPlayerInfo failed for " + uuid + ": " + e.getMessage());
+            }
+        }
+    }
+
     public java.util.Set<String> previewOrphanedPlayers() {
         java.util.Set<String> orphaned = new java.util.HashSet<>();
         synchronized (lock) {


### PR DESCRIPTION
## Summary

- Fixes cross-server `/pay` failing silently when recipient has never joined the sender's server
- `PayCommand` now checks `MessagingService` and `StorageProvider.resolvePlayerByName()` for cross-server player resolution
- `PaymentExecutor` resolves the correct UUID from the shared database, with proper fallback to Bukkit's offline player when `knownOffline` is set
- `MySQLStorageProvider` implements `resolvePlayerByName()` and `persistPlayerInfo()`
- Bumps all module versions from 3.1.0 to 3.1.1
- Updated CHANGELOG.md, cross-server docs, and storage-provider API docs
- Fixes `PayCommandOfflineSequentialFeatureTest` regression

## Test plan

- [ ] `/pay <player>` works when recipient is on a different backend server
- [ ] `/pay <player>` works for local online and offline players
- [ ] `PayCommandOfflineSequentialFeatureTest` passes
- [ ] All CI checks pass
- [ ] Plugin reports version 3.1.1 on startup